### PR TITLE
feat: compatibility to kanidm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ struct OidcQuery {
     code: String,
     state: String,
     #[allow(dead_code)]
-    session_state: String,
+    session_state: Option<String>,
 }
 
 /// oidc session


### PR DESCRIPTION
[kanidm](https://kanidm.com/) does'nt send session_state