### PR TITLE
feat(builder): Add builder pattern for OidcClient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ keywords = [ "axum", "oidc", "openidconnect", "authentication" ]
 thiserror = "2.0"
 axum-core = "0.5"
 axum = { version = "0.8", default-features = false, features = [ "query" ] }
+bon = "3.3"
 tower-service = "0.3"
 tower-layer = "0.3"
 tower-sessions = { version = "0.14", default-features = false, features = [ "axum-core" ] }


### PR DESCRIPTION
As mentioned is various other thread, using the builder pattern will simplify the way we provide parameter to OidcClient. This is a try to migrate the lib to the builder pattern using the `bon` library.

This is not a breaking change, old constructor are updated to delegate to the builder, and kept the same signature.