### PR TITLE
Add Tracing and UserInfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ serde = "1.0"
 futures-util = "0.3"
 reqwest = { version = "0.12", default-features = false }
 urlencoding = "2.1"
+tracing = "0.1.41"

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -1,25 +1,32 @@
 [package]
+edition = "2021"
 name = "basic"
 version = "0.1.0"
-edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.43", features = ["net", "macros", "rt-multi-thread"] }
-axum = { version = "0.8", features = [ "macros" ]}
+axum = { version = "0.8", features = ["macros"] }
 axum-oidc = { path = "./../.." }
+dotenvy = "0.15"
+tokio = { version = "1.43", features = ["macros", "net", "rt-multi-thread"] }
 tower = "0.5"
 tower-sessions = "0.14"
 
-dotenvy = "0.15"
+openidconnect = "4.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.140"
+tracing-subscriber = "0.3.19"
+tracing = "0.1.41"
 
 [dev-dependencies]
+env_logger = "0.11"
+headless_chrome = "1.0"
+log = "0.4"
+reqwest = { version = "0.12", features = [
+    "rustls-tls",
+], default-features = false }
 testcontainers = "0.23"
 tokio = { version = "1.43", features = ["rt-multi-thread"] }
-reqwest = { version = "0.12", features = ["rustls-tls"], default-features = false }
-env_logger = "0.11"
-log = "0.4"
-headless_chrome = "1.0"
 #see https://github.com/rust-headless-chrome/rust-headless-chrome/issues/535
 auto_generate_cdp = "=0.4.4"

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -1,6 +1,12 @@
 use basic::run;
+use tracing::Level;
 #[tokio::main]
 async fn main() {
+    tracing_subscriber::fmt()
+        .with_file(true)
+        .with_line_number(true)
+        .with_max_level(Level::TRACE)
+        .init();
     dotenvy::dotenv().ok();
     let issuer = std::env::var("ISSUER").expect("ISSUER env variable");
     let client_id = std::env::var("CLIENT_ID").expect("CLIENT_ID env variable");

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,14 @@ pub enum MiddlewareError {
     #[error("claims verification: {0:?}")]
     ClaimsVerification(#[from] openidconnect::ClaimsVerificationError),
 
+    #[error("user info retrieval: {0:?}")]
+    UserInfoRetrieval(
+        #[from]
+        openidconnect::UserInfoError<
+            openidconnect::HttpClientError<openidconnect::reqwest::Error>,
+        >,
+    ),
+
     #[error("url parsing: {0:?}")]
     UrlParsing(#[from] openidconnect::url::ParseError),
 
@@ -74,7 +82,7 @@ pub enum MiddlewareError {
 
 #[derive(Debug, Error)]
 pub enum HandlerError {
-    #[error("the redirect handler got accessed without a valid session")]
+    #[error("redirect handler accessed without valid session, session cookie missing?")]
     RedirectedWithoutSession,
 
     #[error("csrf token invalid")]
@@ -153,24 +161,21 @@ impl IntoResponse for ExtractorError {
 
 impl IntoResponse for Error {
     fn into_response(self) -> axum_core::response::Response {
-        match self {
-            _ => (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response(),
-        }
+        tracing::error!(error = self.to_string());
+        (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response()
     }
 }
 
 impl IntoResponse for MiddlewareError {
     fn into_response(self) -> axum_core::response::Response {
-        match self {
-            _ => (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response(),
-        }
+        tracing::error!(error = self.to_string());
+        (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response()
     }
 }
 
 impl IntoResponse for HandlerError {
     fn into_response(self) -> axum_core::response::Response {
-        match self {
-            _ => (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response(),
-        }
+        tracing::error!(error = self.to_string());
+        (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response()
     }
 }

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -7,12 +7,12 @@ use axum_core::{
     response::IntoResponse,
 };
 use http::{request::Parts, uri::PathAndQuery, Uri};
-use openidconnect::{core::CoreGenderClaim, IdTokenClaims};
+use openidconnect::{core::CoreGenderClaim, IdTokenClaims, UserInfoClaims};
 
 /// Extractor for the OpenID Connect Claims.
 ///
 /// This Extractor will only return the Claims when the cached session is valid and [`crate::middleware::OidcAuthMiddleware`] is loaded.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct OidcClaims<AC: AdditionalClaims>(pub IdTokenClaims<AC, CoreGenderClaim>);
 
 impl<S, AC> FromRequestParts<S> for OidcClaims<AC>
@@ -211,5 +211,57 @@ impl IntoResponse for OidcRpInitiatedLogout {
         } else {
             ExtractorError::FailedToCreateRpInitiatedLogoutUri.into_response()
         }
+    }
+}
+
+
+/// Extractor for the OpenID Connect User Info Claims.
+///
+/// This Extractor will only return the User Info Claims when the cached session is valid and [`crate::middleware::OidcAuthMiddleware`] is loaded.
+#[derive(Clone, Debug)]
+pub struct OidcUserClaims<AC: AdditionalClaims>(pub UserInfoClaims<AC, CoreGenderClaim>);
+
+impl<S, AC> FromRequestParts<S> for OidcUserClaims<AC>
+where
+    S: Send + Sync,
+    AC: AdditionalClaims,
+{
+    type Rejection = ExtractorError;
+
+    async fn from_request_parts(parts: &mut Parts, _: &S) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get::<Self>()
+            .cloned()
+            .ok_or(ExtractorError::Unauthorized)
+    }
+}
+
+impl<S, AC> OptionalFromRequestParts<S> for OidcUserClaims<AC>
+where
+    S: Send + Sync,
+    AC: AdditionalClaims,
+{
+    type Rejection = Infallible;
+
+    async fn from_request_parts(parts: &mut Parts, _: &S) -> Result<Option<Self>, Self::Rejection> {
+        Ok(parts.extensions.get::<Self>().cloned())
+    }
+}
+
+impl<AC: AdditionalClaims> Deref for OidcUserClaims<AC> {
+    type Target = UserInfoClaims<AC, CoreGenderClaim>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<AC> AsRef<UserInfoClaims<AC, CoreGenderClaim>> for OidcUserClaims<AC>
+where
+    AC: AdditionalClaims,
+{
+    fn as_ref(&self) -> &UserInfoClaims<AC, CoreGenderClaim> {
+        &self.0
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,4 +1,8 @@
-use axum::{extract::Query, response::Redirect, Extension};
+use axum::{
+    extract::{Query, State},
+    response::Redirect,
+    Extension,
+};
 use openidconnect::{
     core::{CoreGenderClaim, CoreJsonWebKey},
     AccessToken, AccessTokenHash, AuthorizationCode, IdTokenClaims, IdTokenVerifier,
@@ -8,8 +12,8 @@ use serde::Deserialize;
 use tower_sessions::Session;
 
 use crate::{
-    error::HandlerError, AdditionalClaims, AuthenticatedSession, IdToken, OidcClient, OidcSession,
-    SESSION_KEY,
+    error::HandlerError, AdditionalClaims, AuthenticatedSession, Config, IdToken, OidcClient,
+    OidcSession, SESSION_KEY,
 };
 
 /// response data of the openid issuer after login
@@ -21,11 +25,16 @@ pub struct OidcQuery {
     session_state: Option<String>,
 }
 
+#[tracing::instrument(skip(oidcclient), err)]
 pub async fn handle_oidc_redirect<AC: AdditionalClaims>(
     session: Session,
     Extension(oidcclient): Extension<OidcClient<AC>>,
+    State(config): State<Config>,
     Query(query): Query<OidcQuery>,
 ) -> Result<impl axum::response::IntoResponse, HandlerError> {
+    
+    tracing::debug!("start handling oidc redirect");
+
     let mut login_session: OidcSession<AC> = session
         .get(SESSION_KEY)
         .await?
@@ -33,10 +42,12 @@ pub async fn handle_oidc_redirect<AC: AdditionalClaims>(
     // the request has the request headers of the oidc redirect
     // parse the headers and exchange the code for a valid token
 
+    tracing::debug!("validating scrf token");
     if login_session.csrf_token.secret() != &query.state {
         return Err(HandlerError::CsrfTokenInvalid);
     }
 
+    tracing::debug!("obtain token response");
     let token_response = oidcclient
         .client
         .exchange_code(AuthorizationCode::new(query.code.to_string()))?
@@ -47,19 +58,27 @@ pub async fn handle_oidc_redirect<AC: AdditionalClaims>(
         .request_async(&oidcclient.http_client)
         .await?;
 
+    tracing::debug!("extract claims and verify it");
     // Extract the ID token claims after verifying its authenticity and nonce.
     let id_token = token_response
         .id_token()
         .ok_or(HandlerError::IdTokenMissing)?;
-    let id_token_verifier = oidcclient.client.id_token_verifier();
+    let id_token_verifier = oidcclient
+        .client
+        .id_token_verifier()
+        .set_other_audience_verifier_fn(|audience| config.other_audiences.contains(audience));
     let claims = id_token.claims(&id_token_verifier, &login_session.nonce)?;
 
+    tracing::debug!("validate access token hash");
     validate_access_token_hash(
         id_token,
         id_token_verifier,
         token_response.access_token(),
         claims,
-    )?;
+    )
+    .inspect_err(|e| tracing::error!(?e, "Access token hash invalid"))?;
+
+    tracing::debug!("Access token hash validated");
 
     login_session.authenticated = Some(AuthenticatedSession {
         id_token: id_token.clone(),
@@ -70,6 +89,10 @@ pub async fn handle_oidc_redirect<AC: AdditionalClaims>(
         login_session.refresh_token = Some(refresh_token);
     }
 
+    tracing::debug!(
+        "Inserting session and redirecting to {}",
+        &login_session.redirect_url
+    );
     let redirect_url = login_session.redirect_url.clone();
     session.insert(SESSION_KEY, login_session).await?;
 
@@ -79,6 +102,7 @@ pub async fn handle_oidc_redirect<AC: AdditionalClaims>(
 /// Verify the access token hash to ensure that the access token hasn't been substituted for
 /// another user's.
 /// Returns `Ok` when access token is valid
+#[tracing::instrument(skip_all, err)]
 fn validate_access_token_hash<AC: AdditionalClaims>(
     id_token: &IdToken<AC>,
     id_token_verifier: IdTokenVerifier<CoreJsonWebKey>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,10 @@ mod extractor;
 mod handler;
 mod middleware;
 
-pub use extractor::{OidcAccessToken, OidcClaims, OidcRpInitiatedLogout};
+pub use extractor::{OidcAccessToken, OidcClaims, OidcUserClaims, OidcRpInitiatedLogout};
 pub use handler::handle_oidc_redirect;
-pub use middleware::{OidcAuthLayer, OidcAuthMiddleware, OidcLoginLayer, OidcLoginMiddleware};
+pub use middleware::{Config, OidcAuthLayer, OidcAuthMiddleware, OidcLoginLayer, OidcLoginMiddleware};
+pub use openidconnect::Audience;
 
 const SESSION_KEY: &str = "axum-oidc";
 


### PR DESCRIPTION
This PR adds tracing to allow for easier error localization. I've found myself trying to debug a wrong cookie same-site setting and had to add some tracing to find that. So that is basically all the tracing that is added so far, but it's a start.

Since Zitadel sends multiple audiences and there does not seem to be any consensus how it should be handled, I have added the ability to allow additional audiences with a config. See https://github.com/zitadel/zitadel/issues/9200

I have updated the basic example and applied a few clippy lints.

If you want me to make any changes to the PR to get it merged, please let me know.