### PR TITLE
Use openidconnect `ClientId` and `ClientSecret` directly instead of `Box<str>`

### DIFF
--- a/examples/basic/src/lib.rs
+++ b/examples/basic/src/lib.rs
@@ -6,8 +6,8 @@ use axum::{
     Router,
 };
 use axum_oidc::{
-    error::MiddlewareError, handle_oidc_redirect, EmptyAdditionalClaims, OidcAuthLayer, OidcClaims,
-    OidcClient, OidcLoginLayer, OidcRpInitiatedLogout,
+    error::MiddlewareError, handle_oidc_redirect, ClientId, ClientSecret, EmptyAdditionalClaims,
+    OidcAuthLayer, OidcClaims, OidcClient, OidcLoginLayer, OidcRpInitiatedLogout,
 };
 use tokio::net::TcpListener;
 use tower::ServiceBuilder;
@@ -33,9 +33,9 @@ pub async fn run(issuer: String, client_id: String, client_secret: Option<String
     let mut oidc_client = OidcClient::<EmptyAdditionalClaims>::builder()
         .with_default_http_client()
         .with_redirect_url(Uri::from_static("http://localhost:8080/oidc"))
-        .with_client_id(client_id);
+        .with_client_id(ClientId::new(client_id));
     if let Some(client_secret) = client_secret {
-        oidc_client = oidc_client.with_client_secret(client_secret);
+        oidc_client = oidc_client.with_client_secret(ClientSecret::new(client_secret));
     }
     let oidc_client = oidc_client.discover(issuer).await.unwrap().build();
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -11,8 +11,8 @@ pub struct HttpClient(reqwest::Client);
 pub struct RedirectUrl(Uri);
 
 pub struct ClientCredentials {
-    id: Box<str>,
-    secret: Option<Box<str>>,
+    id: ClientId,
+    secret: Option<ClientSecret>,
 }
 
 pub struct Builder<AC: AdditionalClaims, Credentials, Client, HttpClient, RedirectUrl> {
@@ -77,7 +77,7 @@ impl<AC: AdditionalClaims, CLIENT, HTTP, RURL> Builder<AC, (), CLIENT, HTTP, RUR
     /// set client id for authentication with issuer
     pub fn with_client_id(
         self,
-        id: impl Into<Box<str>>,
+        id: impl Into<ClientId>,
     ) -> Builder<AC, ClientCredentials, CLIENT, HTTP, RURL> {
         Builder::<_, _, _, _, _> {
             credentials: ClientCredentials {
@@ -97,7 +97,7 @@ impl<AC: AdditionalClaims, CLIENT, HTTP, RURL> Builder<AC, (), CLIENT, HTTP, RUR
 
 impl<AC: AdditionalClaims, CLIENT, HTTP, RURL> Builder<AC, ClientCredentials, CLIENT, HTTP, RURL> {
     /// set client secret for authentication with issuer
-    pub fn with_client_secret(mut self, secret: impl Into<Box<str>>) -> Self {
+    pub fn with_client_secret(mut self, secret: impl Into<ClientSecret>) -> Self {
         self.credentials.secret = Some(secret.into());
         self
     }
@@ -172,10 +172,7 @@ impl<AC: AdditionalClaims> Builder<AC, ClientCredentials, (), HttpClient, Redire
         let client = Client::from_provider_metadata(
             provider_metadata,
             ClientId::new(self.credentials.id.to_string()),
-            self.credentials
-                .secret
-                .as_ref()
-                .map(|x| ClientSecret::new(x.to_string())),
+            self.credentials.secret.clone(),
         )
         .set_redirect_uri(openidconnect::RedirectUrl::new(
             self.redirect_url.0.to_string(),

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -7,7 +7,7 @@ use axum_core::{
     response::IntoResponse,
 };
 use http::{request::Parts, uri::PathAndQuery, Uri};
-use openidconnect::{core::CoreGenderClaim, IdTokenClaims};
+use openidconnect::{core::CoreGenderClaim, ClientId, IdTokenClaims};
 
 /// Extractor for the OpenID Connect Claims.
 ///
@@ -113,7 +113,7 @@ impl AsRef<str> for OidcAccessToken {
 pub struct OidcRpInitiatedLogout {
     pub(crate) end_session_endpoint: Uri,
     pub(crate) id_token_hint: Box<str>,
-    pub(crate) client_id: Box<str>,
+    pub(crate) client_id: ClientId,
     pub(crate) post_logout_redirect_uri: Option<Uri>,
     pub(crate) state: Option<String>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ mod middleware;
 pub use extractor::{OidcAccessToken, OidcClaims, OidcRpInitiatedLogout};
 pub use handler::handle_oidc_redirect;
 pub use middleware::{OidcAuthLayer, OidcAuthMiddleware, OidcLoginLayer, OidcLoginMiddleware};
+pub use openidconnect::{Audience, ClientId, ClientSecret};
 
 const SESSION_KEY: &str = "axum-oidc";
 
@@ -102,7 +103,7 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
 #[derive(Clone)]
 pub struct OidcClient<AC: AdditionalClaims> {
     scopes: Vec<Box<str>>,
-    client_id: Box<str>,
+    client_id: ClientId,
     client: Client<AC>,
     http_client: reqwest::Client,
     end_session_endpoint: Option<Uri>,


### PR DESCRIPTION
Most types from openidconnect are used directly, so I think `ClientId` and `ClientSecret` should also be used directly.

This PR replaces the uses of `Box<str>` with the appropriate types from the openidconnect crate to better leverage Rust's typesystem and imprpove clarity.