### PR TITLE
Set `refresh_token` to `None` when `ClearSessionFlag` is set

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -298,6 +298,7 @@ where
             let has_logout_ext = response.extensions().get::<ClearSessionFlag>().is_some();
             if let (true, Some(mut login_session)) = (has_logout_ext, login_session) {
                 login_session.authenticated = None;
+                login_session.refresh_token = None;
                 session.insert(SESSION_KEY, login_session).await?;
             }
 


### PR DESCRIPTION
Not setting it to None caused some issues with user-initiated logouts because attempts were made to use the refreshtoken which already had been invalidated by the OIDC provider because of the logout. 