### PR TITLE
Add UserInfo claims, tracing and untrusted audiences

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,24 +3,30 @@ name = "axum-oidc"
 description = "A wrapper for the openidconnect crate for axum"
 version = "0.6.0"
 edition = "2021"
-authors = [ "Paul Z <info@pfz4.de>" ]
+authors = ["Paul Z <info@pfz4.de>"]
 readme = "README.md"
 repository = "https://github.com/pfz4/axum-oidc"
 license = "MPL-2.0"
-keywords = [ "axum", "oidc", "openidconnect", "authentication" ]
+keywords = ["axum", "oidc", "openidconnect", "authentication"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 thiserror = "2.0"
 axum-core = "0.5"
-axum = { version = "0.8", default-features = false, features = [ "query", "original-uri" ] }
+axum = { version = "0.8", default-features = false, features = [
+    "query",
+    "original-uri",
+] }
 tower-service = "0.3"
 tower-layer = "0.3"
-tower-sessions = { version = "0.14", default-features = false, features = [ "axum-core" ] }
-http = "1.2"
+tower-sessions = { version = "0.14", default-features = false, features = [
+    "axum-core",
+] }
+http = "1.3.1"
 openidconnect = "4.0"
 serde = "1.0"
 futures-util = "0.3"
 reqwest = { version = "0.12", default-features = false }
 urlencoding = "2.1"
+tracing = "0.1.41"

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
+edition = "2024"
 name = "basic"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
-tokio = { version = "1.43", features = ["net", "macros", "rt-multi-thread"] }
-axum = { version = "0.8", features = [ "macros" ]}
+axum = { version = "0.8", features = ["macros"] }
 axum-oidc = { path = "./../.." }
+dotenvy = "0.15"
+openidconnect = "4.0.1"
+tokio = { version = "1.48.0", features = ["macros", "net", "rt-multi-thread"] }
 tower = "0.5"
 tower-sessions = "0.14"
-dotenvy = "0.15"
+tracing-subscriber = "0.3.20"
+tracing = "0.1.41"
+serde = "1.0.228"

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,14 @@ pub enum MiddlewareError {
     #[error("claims verification: {0:?}")]
     ClaimsVerification(#[from] openidconnect::ClaimsVerificationError),
 
+    #[error("user info retrieval: {0:?}")]
+    UserInfoRetrieval(
+        #[from]
+        openidconnect::UserInfoError<
+            openidconnect::HttpClientError<openidconnect::reqwest::Error>,
+        >,
+    ),
+
     #[error("url parsing: {0:?}")]
     UrlParsing(#[from] openidconnect::url::ParseError),
 
@@ -77,7 +85,7 @@ pub enum MiddlewareError {
 
 #[derive(Debug, Error)]
 pub enum HandlerError {
-    #[error("the redirect handler got accessed without a valid session")]
+    #[error("redirect handler accessed without valid session, session cookie missing?")]
     RedirectedWithoutSession,
 
     #[error("csrf token invalid")]
@@ -156,24 +164,21 @@ impl IntoResponse for ExtractorError {
 
 impl IntoResponse for Error {
     fn into_response(self) -> axum_core::response::Response {
-        match self {
-            _ => (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response(),
-        }
+        tracing::error!(error = self.to_string());
+        (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response()
     }
 }
 
 impl IntoResponse for MiddlewareError {
     fn into_response(self) -> axum_core::response::Response {
-        match self {
-            _ => (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response(),
-        }
+        tracing::error!(error = self.to_string());
+        (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response()
     }
 }
 
 impl IntoResponse for HandlerError {
     fn into_response(self) -> axum_core::response::Response {
-        match self {
-            _ => (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response(),
-        }
+        tracing::error!(error = self.to_string());
+        (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ mod extractor;
 mod handler;
 mod middleware;
 
-pub use extractor::{OidcAccessToken, OidcClaims, OidcRpInitiatedLogout};
+pub use extractor::{OidcAccessToken, OidcClaims, OidcRpInitiatedLogout, OidcUserInfo};
 pub use handler::handle_oidc_redirect;
 pub use middleware::{OidcAuthLayer, OidcAuthMiddleware, OidcLoginLayer, OidcLoginMiddleware};
 pub use openidconnect::{Audience, ClientId, ClientSecret};
@@ -108,6 +108,7 @@ pub struct OidcClient<AC: AdditionalClaims> {
     http_client: reqwest::Client,
     end_session_endpoint: Option<Uri>,
     auth_context_class: Option<Box<str>>,
+    untrusted_audiences: Vec<Audience>,
 }
 
 /// an empty struct to be used as the default type for the additional claims generic


### PR DESCRIPTION
Rebasing #33 to the master branch.

I have also removed the extra `Config` struct and instead stored the untrusted audiences with the oidcclient. That fits much better into the existing Builder design.